### PR TITLE
Add on_new_tag and on_new_image alerts

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -27,7 +27,7 @@ on:
         default: false
 
 env:
-  CHECK_IMAGE: ghcr.io/knqyf263/aqua-checksums@sha256:c1b998fd1c7f8a832485fbe8b67de9e06e4ea75da66fec8a8477c59fbba752ba
+  CHECK_IMAGE: ghcr.io/knqyf263/aqua-checksums@sha256:60f14e07fd94a8f31432eb20fa07b81f94adeeafbcfc331ac1f809c0d5b9de71
 
 permissions:
   issues: write

--- a/full.yaml
+++ b/full.yaml
@@ -1,5 +1,7 @@
 defaults:
   on_new_release: notify
+  on_new_tag: notify
+  on_new_image: notify
   cosign:
     identity: "https://github\\.com/aquasecurity/"
     oidc_issuer: "https://token\\.actions\\.githubusercontent\\.com"

--- a/quick.yaml
+++ b/quick.yaml
@@ -4,6 +4,8 @@
 
 defaults:
   on_new_release: error
+  on_new_tag: error
+  on_new_image: error
   cosign:
     identity: "https://github\\.com/aquasecurity/"
     oidc_issuer: "https://token\\.actions\\.githubusercontent\\.com"


### PR DESCRIPTION
Alert on new git tags and container image tags to prevent supply chain attacks that create new malicious entries without modifying existing ones.