### PR TITLE
Exclude old node-collector tags in quick check

### DIFF
--- a/quick.yaml
+++ b/quick.yaml
@@ -193,3 +193,6 @@ targets:
       tags: true
     images:
       - repository: ghcr.io/aquasecurity/node-collector
+        # Monitor only 0.3.x+.
+        exclude_tags:
+          - "0.[0-2]*"


### PR DESCRIPTION
Monitor only 0.3.x+ for node-collector in quick mode.