### PR TITLE
Auto-PR state updates on full check, allow :latest digest drift

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -27,7 +27,7 @@ on:
         default: false
 
 env:
-  CHECK_IMAGE: ghcr.io/knqyf263/aqua-checksums@sha256:60f14e07fd94a8f31432eb20fa07b81f94adeeafbcfc331ac1f809c0d5b9de71
+  CHECK_IMAGE: ghcr.io/knqyf263/aqua-checksums@sha256:4f096f0cc74154e262ce405d24fa87dc2e380928fde8035404dd4b9f29ee5f56
 
 permissions:
   issues: write

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,6 +31,8 @@ env:
 
 permissions:
   issues: write
+  contents: write
+  pull-requests: write
 
 jobs:
   check:
@@ -39,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
 
       - name: Pull checker image
         run: docker pull ${{ env.CHECK_IMAGE }}
@@ -84,6 +84,71 @@ jobs:
           args="--deep --on-missing-state init --config /work/full.yaml --state /work/state"
           if [ "$DEBUG" = "true" ]; then args="--debug $args"; fi
           docker run --rm --user "$(id -u):$(id -g)" -e GITHUB_TOKEN -v "$PWD:/work" ${{ env.CHECK_IMAGE }} check $args 2>&1 | tee /tmp/check-output.txt
+
+      - name: Check for state changes
+        id: diff
+        run: |
+          if git diff --quiet state/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat state/
+          fi
+
+      - name: Create state-update PR
+        if: steps.mode.outputs.mode == 'full' && steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -e
+          # Ensure the label exists (idempotent).
+          gh label create "auto-state-update" --color "0E8A16" \
+            --description "Automated state update proposed by the integrity checker" \
+            --force >/dev/null
+
+          timestamp=$(date -u +%Y%m%d-%H%M%S)
+          branch="auto/state-update-${timestamp}-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add state/
+          git commit -m "Auto state update: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          git push origin "$branch"
+
+          findings=""
+          if [ -f /tmp/check-output.txt ]; then
+            findings=$(grep -v '^time=' /tmp/check-output.txt | head -100)
+          fi
+
+          body="Automated state update proposed by the full integrity check. Review the diff against the source of truth (release notes, signed artifacts) before merging.
+
+          **Run:** ${RUN_URL}
+          **Mode:** full
+          "
+
+          if [ -n "$findings" ]; then
+            body="${body}
+          <details>
+          <summary>Findings</summary>
+
+          \`\`\`
+          ${findings}
+          \`\`\`
+
+          </details>
+          "
+          fi
+
+          body="${body}
+          This PR was automatically created by the supply chain integrity checker. Do not merge without verifying digests against the source of truth."
+
+          gh pr create --draft \
+            --title "Auto state update: $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --label "auto-state-update" \
+            --assignee knqyf263 \
+            --body "$body" \
+            --head "$branch"
 
       - name: Handle findings
         env:

--- a/full.yaml
+++ b/full.yaml
@@ -20,6 +20,11 @@ defaults:
   assets: true
   image_exclude_tags:
     - "canary"
+  # Tags whose digest is expected to move on each release (latest, arch variants).
+  # A digest change on these tags updates state instead of raising an error.
+  image_mutable_tags:
+    - "latest"
+    - "latest-*"
 
 targets:
   - name: trivy


### PR DESCRIPTION
## Summary

Wire vigilis's new `image_mutable_tags` support into the check workflow and stop creating false-positive alerts for legitimate `:latest` drift.

Three commits:

1. **Declare `:latest` and `:latest-*` as mutable** in `full.yaml` so vigilis overwrites the recorded digest (and re-verifies cosign) instead of erroring when these tags move on release.
2. **Bump `CHECK_IMAGE`** to the build containing [knqyf263/vigilis#1](https://github.com/knqyf263/vigilis/pull/1).
3. **Auto-create draft PRs on full-check state diffs.** After a full run, if vigilis modified `state/`, the workflow commits the diff to `auto/state-update-<timestamp>-<runid>`, pushes it, and opens a draft PR labelled `auto-state-update`. Existing Issue behaviour for hard failures is unchanged.

Previously, every legitimate aquasecurity release produced an alert that required a manual state rewrite (e.g. #19 → #20). Now those land as draft PRs whose diff can be reviewed and merged.

## Behaviour matrix (full check)

| Condition | Outcome |
|---|---|
| No errors, no state diff | Green, nothing to do |
| New entry detected (`on_new_*: notify`, state appended) | Draft PR only |
| `:latest` moved, cosign verified | Draft PR only (WARN finding) |
| `:latest` moved, cosign SigFailed | Issue only (vigilis leaves state untouched) |
| Non-mutable digest changed | Issue only |
| Mixed (new entries + unrelated error) | Both PR and Issue |

## Required permissions

The workflow now needs `contents: write` (push PR branch) and `pull-requests: write` (create PR) in addition to `issues: write`. The Actions token scope is already sufficient on this repo.

## Follow-ups

- Per-target / per-finding alert dedup is tracked in #22.
- The `auto-state-update` label is auto-created by the workflow on first run.

## Test plan

- [ ] Next scheduled full check runs without errors (or produces a reviewable draft PR).
- [ ] Next legitimate `:latest` move lands as a draft PR, not an issue.
- [ ] Confirm `auto-state-update` label is created.