### PR TITLE
fix: skip auto pr creation when open state-update pr exists

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -103,9 +103,9 @@ jobs:
         run: |
           set -e
           # Skip if there's already an open auto-state-update PR.
-          existing=$(gh pr list --state open --label "auto-state-update" --json number --jq 'length')
-          if [ "$existing" -gt 0 ]; then
-            echo "::warning::State changes detected but an open auto-state-update PR already exists. Skipping."
+          existing_pr=$(gh pr list --state open --label "auto-state-update" --json number --jq '.[0].number // empty')
+          if [ -n "$existing_pr" ]; then
+            echo "::warning::State changes detected but auto-state-update PR #${existing_pr} is already open. Skipping."
             exit 0
           fi
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -102,6 +102,13 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -e
+          # Skip if there's already an open auto-state-update PR.
+          existing=$(gh pr list --state open --label "auto-state-update" --json number --jq 'length')
+          if [ "$existing" -gt 0 ]; then
+            echo "::warning::State changes detected but an open auto-state-update PR already exists. Skipping."
+            exit 0
+          fi
+
           # Ensure the label exists (idempotent).
           gh label create "auto-state-update" --color "0E8A16" \
             --description "Automated state update proposed by the integrity checker" \


### PR DESCRIPTION
Closes #30

## Summary
- Add duplicate check to the "Create state-update PR" step mirroring the existing `integrity-alert` issue guard
- Prevents piling up open `auto-state-update` PRs (currently #26, #27, #28, #29) every time the full check detects state drift

## Test plan
- [ ] After merge, trigger a full check run via workflow_dispatch with an open `auto-state-update` PR present and confirm the step logs "already exists. Skipping." and exits cleanly
- [ ] Close all open `auto-state-update` PRs, then trigger a run that has state diffs and confirm a single new PR is created