### PR TITLE
fix: sign auto state-update commits via git data api

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -122,25 +122,23 @@ jobs:
           # required_signatures on main. github-actions[bot] commits made
           # through this API path are signed by GitHub's web-flow key.
           parent_sha=$(git rev-parse HEAD)
-          base_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${parent_sha}" --jq '.tree.sha')
+          base_tree=$(git rev-parse "HEAD^{tree}")
 
           # Collect tree entries for every changed file under state/.
           tree_entries='[]'
-          while IFS=$'\t' read -r status path; do
-            case "$status" in
-              D)
-                tree_entries=$(echo "$tree_entries" | jq --arg p "$path" \
-                  '. + [{path:$p, mode:"100644", type:"blob", sha:null}]')
-                ;;
-              *)
-                blob_b64=$(base64 < "$path" | tr -d '\n')
-                blob_sha=$(jq -n --arg c "$blob_b64" '{encoding:"base64", content:$c}' | \
-                  gh api -X POST "repos/${GITHUB_REPOSITORY}/git/blobs" --input - --jq '.sha')
-                tree_entries=$(echo "$tree_entries" | jq --arg p "$path" --arg s "$blob_sha" \
-                  '. + [{path:$p, mode:"100644", type:"blob", sha:$s}]')
-                ;;
-            esac
-          done < <(git diff --name-status HEAD -- state/)
+          while IFS= read -r path; do
+            blob_file="${RUNNER_TEMP}/blob.b64"
+            base64 < "$path" | tr -d '\n' > "$blob_file"
+            blob_sha=$(jq -n --rawfile c "$blob_file" '{encoding:"base64", content:$c}' | \
+              gh api -X POST "repos/${GITHUB_REPOSITORY}/git/blobs" --input - --jq '.sha')
+            tree_entries=$(echo "$tree_entries" | jq --arg p "$path" --arg s "$blob_sha" \
+              '. + [{path:$p, mode:"100644", type:"blob", sha:$s}]')
+          done < <(git diff --name-only --diff-filter=AM HEAD -- state/)
+
+          while IFS= read -r path; do
+            tree_entries=$(echo "$tree_entries" | jq --arg p "$path" \
+              '. + [{path:$p, mode:"100644", type:"blob", sha:null}]')
+          done < <(git diff --name-only --diff-filter=D HEAD -- state/)
 
           new_tree=$(jq -n --arg bt "$base_tree" --argjson entries "$tree_entries" \
             '{base_tree:$bt, tree:$entries}' | \

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -125,6 +125,8 @@ jobs:
           base_tree=$(git rev-parse "HEAD^{tree}")
 
           # Collect tree entries for every changed file under state/.
+          # ls-files --modified --others picks up tracked modifications AND
+          # untracked new files, matching the old `git add state/` behavior.
           tree_entries='[]'
           while IFS= read -r path; do
             blob_file="${RUNNER_TEMP}/blob.b64"
@@ -133,12 +135,12 @@ jobs:
               gh api -X POST "repos/${GITHUB_REPOSITORY}/git/blobs" --input - --jq '.sha')
             tree_entries=$(echo "$tree_entries" | jq --arg p "$path" --arg s "$blob_sha" \
               '. + [{path:$p, mode:"100644", type:"blob", sha:$s}]')
-          done < <(git diff --name-only --diff-filter=AM HEAD -- state/)
+          done < <(git ls-files --modified --others --exclude-standard -- state/)
 
           while IFS= read -r path; do
             tree_entries=$(echo "$tree_entries" | jq --arg p "$path" \
               '. + [{path:$p, mode:"100644", type:"blob", sha:null}]')
-          done < <(git diff --name-only --diff-filter=D HEAD -- state/)
+          done < <(git ls-files --deleted -- state/)
 
           new_tree=$(jq -n --arg bt "$base_tree" --argjson entries "$tree_entries" \
             '{base_tree:$bt, tree:$entries}' | \

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -116,12 +116,42 @@ jobs:
 
           timestamp=$(date -u +%Y%m%d-%H%M%S)
           branch="auto/state-update-${timestamp}-${GITHUB_RUN_ID}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          git add state/
-          git commit -m "Auto state update: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          git push origin "$branch"
+          commit_message="Auto state update: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          # Build a signed commit via the Git Data API so it satisfies
+          # required_signatures on main. github-actions[bot] commits made
+          # through this API path are signed by GitHub's web-flow key.
+          parent_sha=$(git rev-parse HEAD)
+          base_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${parent_sha}" --jq '.tree.sha')
+
+          # Collect tree entries for every changed file under state/.
+          tree_entries='[]'
+          while IFS=$'\t' read -r status path; do
+            case "$status" in
+              D)
+                tree_entries=$(echo "$tree_entries" | jq --arg p "$path" \
+                  '. + [{path:$p, mode:"100644", type:"blob", sha:null}]')
+                ;;
+              *)
+                blob_b64=$(base64 < "$path" | tr -d '\n')
+                blob_sha=$(jq -n --arg c "$blob_b64" '{encoding:"base64", content:$c}' | \
+                  gh api -X POST "repos/${GITHUB_REPOSITORY}/git/blobs" --input - --jq '.sha')
+                tree_entries=$(echo "$tree_entries" | jq --arg p "$path" --arg s "$blob_sha" \
+                  '. + [{path:$p, mode:"100644", type:"blob", sha:$s}]')
+                ;;
+            esac
+          done < <(git diff --name-status HEAD -- state/)
+
+          new_tree=$(jq -n --arg bt "$base_tree" --argjson entries "$tree_entries" \
+            '{base_tree:$bt, tree:$entries}' | \
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/trees" --input - --jq '.sha')
+
+          new_commit=$(jq -n --arg msg "$commit_message" --arg tree "$new_tree" --arg parent "$parent_sha" \
+            '{message:$msg, tree:$tree, parents:[$parent]}' | \
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/commits" --input - --jq '.sha')
+
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f "ref=refs/heads/${branch}" -f "sha=${new_commit}" >/dev/null
 
           findings=""
           if [ -f /tmp/check-output.txt ]; then
@@ -151,7 +181,7 @@ jobs:
           This PR was automatically created by the supply chain integrity checker. Do not merge without verifying digests against the source of truth."
 
           gh pr create --draft \
-            --title "Auto state update: $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --title "$commit_message" \
             --label "auto-state-update" \
             --assignee knqyf263 \
             --body "$body" \


### PR DESCRIPTION
Closes #32

## Summary
- Replaces `git commit` / `git push` in the `Create state-update PR` step with a Git Data API flow (`blobs` → `trees` → `commits` → `refs`)
- Produces commits signed by GitHub's web-flow key when run with `GITHUB_TOKEN`, satisfying the `required_signatures` branch protection on `main`
- Handles adds/modifies via blob creation and deletions via `sha: null` tree entries

## Empirical findings

Tested 4 combinations on this repo via throwaway `probe/*` workflows:

| token × API | verified |
|---|---|
| PAT + Contents API | `false` (unsigned) |
| PAT + Git Data API | `false` (unsigned) |
| `GITHUB_TOKEN` + Contents API | `true` (valid, signed by `GitHub`) |
| `GITHUB_TOKEN` + Git Data API | `true` (valid, signed by `GitHub`) |

So bot-token requests via REST API get signed by web-flow regardless of which API is chosen — the distinction is bot-vs-user token, not Contents-vs-GitData API.

## Why Git Data API here

Contents API (`PUT /contents/{path}`) commits one file per request, which would produce up to 9 commits per state update. Git Data API composes a single commit touching all changed `state/*.tsv` files at once, matching the existing `git add state/ && git commit` atomicity. Same pattern as [`suzuki-shunsuke/commit-action`](https://github.com/suzuki-shunsuke/commit-action).

## Test plan
- [ ] After merge, dispatch the `Check` workflow manually with `mode=full` (inducing a state drift if needed by temporarily editing a `state/*.tsv`) and verify the resulting auto PR's commit shows `Verified`
- [ ] Confirm the auto PR can be merged via `gh pr merge --squash` without `--admin`