### PR TITLE
revert: remove e2e probe drift injection

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -80,9 +80,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEBUG: ${{ inputs.debug }}
         run: |
-          # E2E PROBE: inject synthetic drift instead of running the real checker
-          echo "# e2e probe drift ${GITHUB_RUN_ID}" >> state/setup-trivy.tsv
-          echo "probe drift injected" | tee /tmp/check-output.txt
+          set -o pipefail
+          args="--deep --on-missing-state init --config /work/full.yaml --state /work/state"
+          if [ "$DEBUG" = "true" ]; then args="--debug $args"; fi
+          docker run --rm --user "$(id -u):$(id -g)" -e GITHUB_TOKEN -v "$PWD:/work" ${{ env.CHECK_IMAGE }} check $args 2>&1 | tee /tmp/check-output.txt
 
       - name: Check for state changes
         id: diff

--- a/state/setup-trivy.tsv
+++ b/state/setup-trivy.tsv
@@ -1,4 +1,3 @@
 type	identifier	digest	signature	sig_method	tlog_timestamp	created_at
 release	v0.2.6	3fb12ec12f41e471780db15c232d5dd185dcb514	-			2026-03-19T21:43:56Z
 tag	v0.2.6	3fb12ec12f41e471780db15c232d5dd185dcb514	-			-
-# e2e probe drift 24882595586


### PR DESCRIPTION
Reverts the synthetic drift injection and the stray state line introduced during the end-to-end merge test.

Context: an E2E test intentionally modified the `Run full check` step to append a probe line to `state/setup-trivy.tsv` and skip the real checker. The auto PR (#34) that validated `required_signatures` end-to-end merged successfully (the whole point of the test), but the merge brought the probe injection into `main`. This PR restores the original docker-based checker step and removes the probe line.

## Files
- `.github/workflows/check.yaml` — restore `Run full check` step
- `state/setup-trivy.tsv` — drop the `# e2e probe drift ...` line