### PR TITLE
fix: exclude main tags from integrity check

### DIFF
--- a/full.yaml
+++ b/full.yaml
@@ -20,6 +20,7 @@ defaults:
   assets: true
   image_exclude_tags:
     - "canary"
+    - "main*"
   # Tags whose digest is expected to move on each release (latest, arch variants).
   # A digest change on these tags updates state instead of raising an error.
   image_mutable_tags:

--- a/state/kube-bench.tsv
+++ b/state/kube-bench.tsv
@@ -1503,9 +1503,6 @@ image	docker.io/aquasec/kube-bench:lizrice-patch-4	sha256:e4d6a7f4c4614a9372740a
 image	docker.io/aquasec/kube-bench:lizrice-patch-5	sha256:aca92b551bf873594ab7c0089dc76c976ef19a5a225d1309b0df41c8dab72c57	unsigned			-
 image	docker.io/aquasec/kube-bench:logo	sha256:6be683adf679f5286d5dd1f3004e06327e11b7b7e034047af0243c1a2eae5bb5	unsigned			-
 image	docker.io/aquasec/kube-bench:lower-case-file-names-mkdocks	sha256:022be94331e80dd54580c45e66d56ec409b53b1235175812b123e80cd6379b0f	unsigned			-
-image	docker.io/aquasec/kube-bench:main	sha256:6c3a7ed70ff5e386dfc2d695d9154e9785715f335b136d14d3d58c6303629f9d	unsigned			-
-image	docker.io/aquasec/kube-bench:main-ubi	sha256:2c645c00cc3ef6534ee1cfd175c85a40dd97a1dee006727565b739d0bbc47208	unsigned			-
-image	docker.io/aquasec/kube-bench:main-ubi-fips	sha256:ce50d5506678a507a45568e898063a81e018fbf6eee6ebd4a034142cb8a577f2	unsigned			-
 image	docker.io/aquasec/kube-bench:manifest-extension	sha256:9cc6c80d9069555b392686d838d06bd5b566d07db3c1ccaae2829e33096c1f16	unsigned			-
 image	docker.io/aquasec/kube-bench:master-to-main	sha256:810869d01cd5640dff727d76dc647a89d9421dc5999f246e47c9a70a3e43c57c	unsigned			-
 image	docker.io/aquasec/kube-bench:migrate-to-bench-common	sha256:5e6d1a7e6b0c47b46c9baffce37a3ea6a5f59fbf195a931d10d2e5e114355318	unsigned			-

--- a/state/trivy-operator.tsv
+++ b/state/trivy-operator.tsv
@@ -3526,11 +3526,6 @@ image	docker.io/aquasec/trivy-operator:0.9.1-ubi8-arm64	sha256:10e596227a5cc80b7
 image	docker.io/aquasec/trivy-operator:0.9.1-ubi8-ppc64le	sha256:6762123154f3f7b08dfafb7e3ffc549a59943ee1ba11632024cd3441f455bcac	skipped			-
 image	docker.io/aquasec/trivy-operator:0.9.1-ubi8-s390x	sha256:b84007b8dea464838170d796ccda1c3addd1b79b659eaf46327951d9c76c0014	skipped			-
 image	docker.io/aquasec/trivy-operator:e2e	sha256:2740bcbadc79d2eef64a7f349450bdff2089981ac3fcc97f80f4d3c6b8ae361a	unsigned			-
-image	docker.io/aquasec/trivy-operator:main	sha256:93ce1337bc21d5ce121cefba332bbe1987fdec149b966d0c57c059de87a91151	unsigned			-
-image	docker.io/aquasec/trivy-operator:main-arm64	sha256:093cd6e242118dd4f75df4618089c1e9fd0f0adb0d819852f251348f2f724648	skipped			-
-image	docker.io/aquasec/trivy-operator:main-ppc64	sha256:eff066a273912ae9b3eddc4c24465734e08b9208c24b41da5708fa1bd581cb10	unsigned			-
-image	docker.io/aquasec/trivy-operator:main-ubi8-x86	sha256:a60b98e4b8db7a689c9b32b6302460e11d453a6f89e4dfa9ca39b15f2f812102	unsigned			-
-image	docker.io/aquasec/trivy-operator:main-x86	sha256:0af44022db2cd74a7f37d67574a5fd0a038c2baa1fe944ea38c62dcd670db7e7	unsigned			-
 image	ghcr.io/aquasecurity/trivy-operator:0.1.4	sha256:e8568f9332091cdfdd58858b5e3dfddf4b918e4e19f5988ef211d6ede3d445c5	verified	cosign:tag-based	2022-07-19T20:02:39Z	-
 image	ghcr.io/aquasecurity/trivy-operator:0.1.4-amd64	sha256:b8a785d785899c488ea042b57d07d24b2d295044cc53416059d67291f0ac3057	skipped			-
 image	ghcr.io/aquasecurity/trivy-operator:0.1.4-arm64	sha256:99f98be0b565123bd41cd24fb2f6acaba50e4cb28488378d8b37e5aff6237829	skipped			-


### PR DESCRIPTION
## Summary
- `:main` tags are floating tags tied to the main branch, so their digests change on every commit, causing false-positive integrity alerts
- Added `"main*"` to `image_exclude_tags` in `full.yaml` to exclude them entirely
- `quick.yaml` already excludes `main` tags for kube-bench via the `[a-u]*` pattern

## Related Issue
- Closes #39